### PR TITLE
feat: use d666 notation for 'more spellbooks'

### DIFF
--- a/resources/more-spellbooks.md
+++ b/resources/more-spellbooks.md
@@ -12,222 +12,222 @@ Note assume damage rolls are against HP unless otherwise noted (e.g. 1d6 damage 
 
 |      |                                                             |                                                              |
 | ---- | ----------------------------------------------------------- | ------------------------------------------------------------ |
-| 1    | [Adaptive Skin](#adaptive-skin)                             | Target can exist comfortably in hot or cold environments.    |
-| 2    | [Addle Brain](#addle-brain)                                 | Target must pass WIL save or drop to 0 WIL for 1 hour.       |
-| 3    | [Animal Call](#animal-call)                                 | Summons a mundane beast. It holds no loyalty towards you or your allies. |
-| 4    | [Anti-Magic Globe](#anti-magic-globe)                       | A thin shell of magical protection surrounds a small area around the caster. For every additional minute the globe is active they take one additional Fatigue. |
-| 5    | [Arachnid's Finesse](#arachnids-finesse)                    | Target can walk on walls and ceilings.                       |
-| 6    | [Arcane Arrow](#arcane-arrow)                               | Green energy bursts from your fingers, dealing 1d6 damage and ignoring mundane armor. |
-| 7    | [Arcane Confinement](#arcane-confinement)                   | Target is bound by magical rope, able only to speak but nothing more. |
-| 8    | [Arcane Epistle](#arcane-epistle)                           | You write a letter that only its intended reader can understand. |
-| 9    | [Arcane Fireworks](#arcane-fireworks)                       | Target flame becomes a great conflagration of heat, light and sound. |
-| 10   | [Arcane Stain](#arcane-stain)                               | Inscribes an invisible rune you can feel. Suffer 1d4 WIL loss if removed. |
-| 11   | [Architect's Eye](#architects-eye)                          | Any hidden doors within 60ft light up as if on fire.         |
-| 12   | [Architect's Perfection](#architects-perfection)            | Create a holographic wall, floor, or ceiling that looks absolutely real. |
-| 13   | [Astral Step](#astral-step)                                 | You and anyone touching you instantly transport to a known location you have been to before. |
-| 14   | [Banishment](#banishment)                                   | WIL save or creature to returns to native plane.             |
-| 15   | [Become Unseen](#become-unseen)                             | Target becomes invisible for 1 hour, and are still able use abilities and attack without detection. Afterwards they become incapacitated (deprived) |
-| 16   | [Beguilement](#beguilement)                                 | Target humanoid must make a WIL save or is controlled telepathically. |
-| 17   | [Bewildering Fog](#bewildering-fog)                         | A hazy fog surrounds you in a radius of 20ft. Attacks within the mist are impaired. |
-| 18   | [Blazing Defense](#blazing-defense)                         | You manifest a shield of flame (+1 Armor, 1d6 damage). Fire cannot hurt you. |
-| 19   | [Blessing](#blessing)                                       | Target’s attacks are enhanced and non-Blast attacks are impaired against them until they next take damage. |
-| 20   | [Bolster](#bolster)                                         | A person you can see is emboldened by your words for a few minutes: their attacks are enhanced and they cannot become deprived. |
-| 21   | [Bound](#bound)                                             | Target can make a single jump to any place they can see.     |
-| 22   | [Boundless Message](#boundless-message)                     | Delivers a single sentence to any one creature instantaneously, no matter the distance. |
-| 23   | [Breath Soup](#breath-soup)                                 | Blocks vision and slows movement.                            |
-| 24   | [Burning Missile](#burning-missile)                         | You fire an acid missile that does 1d6 damage to a target for every round it is not washed off. |
-| 25   | [Burnishing Bubble](#burnishing-bubble)                     | Target is enclosed by an impenetrable sphere that rolls along the ground, unless they pass a DEX save. |
-| 26   | [Calcify](#calcify)                                         | Target object turns to stone at the caster's touch. Living targets save vs STR. |
-| 27   | [Catsense](#catsense)                                       | Target has heightened senses for the next hour, especially at night. |
-| 28   | [Chilling Graze](#chilling-graze)                           | Target loses 1d4+1 STR and is deprived.                      |
-| 29   | [Cinder Flesh](#cinder-flesh)                               | Energy beams burn enemies (1d10 blast damage) in a straight line. |
-| 30   | [Circle of Arcane Protection](#circle-of-arcane-protection) | Magical or godly beings cannot enter a 10ft circle.          |
-| 31   | [Cleanse](#cleanse)                                         | Rotten or poisoned food becomes edible.                      |
-| 32   | [Cold Spray](#cold-spray)                                   | A spray of cold air does d6 damage 20ft in one direction.    |
-| 33   | [Conceal Object](#conceal-object)                           | Masks an object against divination or scrying.               |
-| 34   | [Conquer Gravity](#conquer-gravity)                         | Target moves up or down according to your whims.             |
-| 35   | [Cosmic Fingertips](#cosmic-fingertips)                     | Your hands sculpt stone, rock or minerals into any form you please. |
-| 36   | [Coup de Grâce](#coup-de-grâce)                             | An ally's next attack ignores armor and takes damage directly from their target's STR. |
-| 37   | [Craft from Clay](#craft-from-clay)                         | Any natural, earthen target is transformed (rock to mud, lava to rock, etc). |
-| 38   | [Create Unlife](#create-unlife)                             | Creates 1d4 undead skeletons and zombies from corpses. WIL save every hour to control them. |
-| 39   | [Curse of the Sightless](#curse-of-the-sightless)           | Anyone within eyesight must make a WIL save or be blinded.   |
-| 40   | [Curse Unlife](#curse-unlife)                               | Deals 1d4+2 STR loss to one undead, ignoring armor and resistances. |
-| 41   | [Cure-All](#cure-all)                                       | A single illness or disease dissipates at your touch.        |
-| 42   | [Cute Ink](#cute-ink)                                       | A single page in a book can be altered to hide its true content. |
-| 43   | [Darksight](#darksight)                                     | Target can see 60 ft. in total darkness.                     |
-| 44   | [Death's Breath](#deaths-breath)                            | You summon a poisonous cloud (d6 STR loss) you can control.  |
-| 45   | [Devil's Comedian](#devils-comedian)                        | WIL save or target laughs uncontrollably, unable to take any action. |
-| 46   | [Disaster Fluid](#disaster-fluid)                           | Anything in a 10ft square becomes slippery; DEX save to avoid slipping. |
-| 47   | [Disrupt Scry](#disrupt-scry)                               | Future divinations of one creature or object are misled according to your will. |
-| 48   | [Doppleganger](#doppleganger)                               | You spawn 1d6 decoy duplicates of someone you touch. Decoys are dispelled with a touch. |
-| 49   | [Doubleskin](#doubleskin)                                   | Target humanoid doubles in size.                             |
-| 50   | [Dreampoison](#dreampoison)                                 | Target is deprived after suffering a night of bad dreams.    |
-| 51   | [Dreamtalker](#dreamtalker)                                 | Sends a message to anyone currently asleep.                  |
-| 52   | [Earsplit](#earsplit)                                       | Anyone within earshot is deafened.                           |
-| 53   | [Easy Descent](#easy-descent)                               | Objects or creatures nearby fall very slowly.                |
-| 54   | [Edifice](#edifice)                                         | You summon a stone wall up to 20ft wide that you can control. |
-| 55   | [Energize Rope](#energize-rope)                             | A rope-like objects moves at your command.                   |
-| 56   | [Ensorcelled](#ensorcelled)                                 | Creatures are enraptured for a few minutes unless they pass a WIL save. |
-| 57   | [Envision](#envision)                                       | Spies on a target you have met, even across vast distances. On a WIL save, they can feel your presence. |
-| 58   | [Ephemeral Audio](#ephemeral-audio)                         | Point to a spot. Anyone nearby hears a sound you choose at any volume. |
-| 59   | [Epidemic](#epidemic)                                       | Infects target with disease, which spreads until the source of magic is destroyed. |
-| 60   | [Extraplanar Convocation](#extraplanar-convocation)         | Summons any extraplanar being onto your plane. It holds no loyalty towards you or your allies. |
-| 61   | [Extraplanar Request](#extraplanar-request)                 | Ask a single question of a random extraplanar entity.        |
-| 62   | [Feline Dexterity](#feline-dexterity)                       | Target becomes limber, lithe and as fast as quicksilver.     |
-| 63   | [Find Virulence](#find-virulence)                           | Detects poison in any creature or object within 30ft.        |
-| 64   | [Fire Curse](#fire-curse)                                   | An object you touch is imbued with a hidden flame-trap dealing 1d4+2 STR loss. |
-| 65   | [Firey Missile](#firey-missile)                             | A bow you touch can fire flaming arrows (1d10 damage) for one minute. |
-| 66   | [Fish Lung](#fish-lung)                                     | A target can breathe underwater until they surface again.    |
-| 67   | [Fleetfooted](#fleetfooted)                                 | One creature moves at double speed.                          |
-| 68   | [Flicker](#flicker)                                         | Target randomly vanishes and reappears once at will.         |
-| 69   | [Fog of Nausea](#fog-of-nausea)                             | A cloud of nauseating vapors pours out from the Spellbook's pages. Anyone nearby makes a STR save or vomit uncontrollably. |
-| 70   | [Fold Portal](#fold-portal)                                 | A door you touch opens into another door you've stepped through before until it is shut again. |
-| 71   | [Foolishness](#foolishness)                                 | A target you touch becomes vulnerable to wild mood swings, sweeping conclusions and silly behavior. They also lose 1d6 WIL for 24 hours (down to a minimum of 1). |
-| 72   | [Fortify](#fortify)                                         | Damage from heat, ice, acid or electricity are impaired against a target for the next hour. |
-| 73   | [Frozen Corpse](#frozen-corpse)                             | A corpse you touch is preserved.                             |
-| 74   | [Gale](#gale)                                               | You summon an impenetrable wall of energy up to 15ft wide.   |
-| 75   | [Ghost Whisper](#ghost-whisper)                             | You and a sympathetic ally are linked, able to converse in short sentences for an hour. |
-| 76   | [Gift of Flight](#gift-of-flight)                           | Target can fly for a short while.                            |
-| 77   | [Glacier](#glacier)                                         | You create a wall of ice (15 HP, 3 Armor) around a creature you choose. |
-| 78   | [Gorgon's Gaze](#gorgons-gaze)                              | Target is transformed into a statue on a failed WIL save. A success reverses the spell; holder must pass a WIL save or the book is destroyed. |
-| 79   | [Great Ball of Fire](#great-ball-of-fire)                   | You fire a ball of flame (1d10 damage) up to 20 feet away.   |
-| 80   | [Hand of the Protector](#hand-of-the-protector)             | A giant, floating hand blocks all damage from a single opponent until you are safe from danger. |
-| 81   | [Healing Grace](#healing-grace)                             | A target heals 1d6 STR, and you become deprived until you take the time to mediate, pray or sleep. |
-| 82   | [Heatless Torch](#heatless-torch)                           | Turns any object into a permanent, heatless torch.           |
-| 83   | [Hedgemagick](#hedgemagick)                                 | You perform a minor magical trick (create flame, wind, light or sound). |
-| 84   | [Hempen Hoop](#hempen-hoop)                                 | A rope moves at your command.                                |
-| 85   | [Hide Mind](#hide-mind)                                     | The next person to scry your mind or your whereabouts is fooled. |
-| 86   | [Hoodwink Monster](#hoodwink-monster)                       | Target monster makes a WIL save or treats you as an ally.    |
-| 87   | [Hoodwink Person](#hoodwink-person)                         | Target becomes a friend until out of sight.                  |
-| 88   | [Hovering Protection](#hovering-protection)                 | A hovering, transparent disk materializes around an ally granting 1 Armor. |
-| 89   | [Ice Ray](#ice-ray)                                         | Ice and snow flow from your fingerprints, dealing 1d8 damage (blast) in a straight line. |
-| 90   | [Icy Tempest](#icy-tempest)                                 | Hail deals 1d12 damage in a 20ft radius.                     |
-| 91   | [Ill Fate](#ill-fate)                                       | Target automatically fails next their next save.             |
-| 92   | [Illusory Landscape](#illusory-landscape)                   | You can make one type of terrain appear like another.        |
-| 93   | [Incorporeal Shrug](#incorporeal-shrug)                     | Ignore any one attack.                                       |
-| 94   | [Induce Despair](#induce-despair)                           | Target must pass a WIL save or its attacks are impaired.     |
-| 95   | [Induce Horror](#induce-horror)                             | Target makes a WIL save or flees.                            |
-| 96   | [Inferno](#inferno)                                         | You summon a flaming wall up to 15ft wide. Anyone passing through suffers 1d6 STR loss. |
-| 97   | [Influence](#influence)                                     | Target gains armor 3 but running and swimming are impossible. |
-| 98   | [Insubstantiate](#insubstantiate)                           | Target becomes insubstantial and can float.                  |
-| 99   | [Kraken's Curse](#krakens-curse)                            | Tentacles grapple all within 20 ft, STR save to break free.  |
-| 100  | [Lamp's Hue](#lamps-hue)                                    | Target object shines like a torch for one hour.              |
-| 101  | [Latch](#latch)                                             | An unlocked box, cabinet or door opens or closes at your command. |
-| 102  | [Librarian's Trap](#librarians-trap)                        | Deals 1d4+2 STR loss when read.                              |
-| 103  | [Lichsense](#lichsense)                                     | You feel any undead within 60ft. WIL save to avoid detection by intelligent undead. |
-| 104  | [Light Show](#light-show)                                   | You control a dazzling display of light and color.           |
-| 105  | [Lightning Strike](#lightning-strike)                       | Electricity flings from your fingertips doing 1d12 damage (blast) in a line. |
-| 106  | [Linguist](#linguist)                                       | For the next hour you can speak and understand any mundane language. |
-| 107  | [Magic Seal](#magic-seal)                                   | Magically locks a door, portal or chest.                     |
-| 108  | [Major Genesis](#major-genesis)                             | Creates an object of nonliving stone or metal no greater than 5 cubic foot in size. |
-| 109  | [Maker](#maker)                                             | Transforms raw materials into finished items.                |
-| 110  | [Manic Fury](#manic-fury)                                   | A target's attacks are enhanced. They must make a WIL save after a successful killing or lose control, attacking anyone in sight. |
-| 111  | [Masquerade](#masquerade)                                   | You assume the likeness of a similar creature you have seen. |
-| 112  | [Master Undead](#master-undead)                             | Undead creatures obey your command. Intelligent undead make a WIL save. |
-| 113  | [Mental Tripwire](#mental-tripwire)                         | Intruders set off an alarm audible only to you.              |
-| 114  | [Mind Bond](#mind-bond)                                     | Two allies can communicate via a mental link for the rest of the day. |
-| 115  | [Mind Reader](#mind-reader)                                 | You can see or hear any person you have met before.          |
-| 116  | [Miniaturize](#miniaturize)                                 | An object shrinks to one tenth its size.                     |
-| 117  | [Minor Aegis](#minor-aegis)                                 | A target you touch ignores the next instance of harm from a specific source. |
-| 118  | [Minor Genesis](#minor-genesis)                             | Creates an object of nonliving matter no greater than one cubic foot in size. |
-| 119  | [Mirage](#mirage)                                           | You summon a noiseless & simple illusion of your choice.     |
-| 120  | [Molasses Veins](#molasses-veins)                           | A single target moves at half speed.                         |
-| 121  | [Murky Bubble](#murky-bubble)                               | You create a bubble supernatural shadow within a 20ft radius. |
-| 122  | [Necrotic Touch](#necrotic-touch)                           | Target must DEX save or is paralyzed.                        |
-| 123  | [Obfuscate](#obfuscate)                                     | Target cannot be observed either through divination or scrying. |
-| 124  | [Obfuscation](#obfuscation)                                 | Changes your appearance.                                     |
-| 125  | [Obscuring Mist](#obscuring-mist)                           | A rolling fog obscures vision in a 300ft radius.             |
-| 126  | [Opaque Cover](#opaque-cover)                               | Details about your person become obscured and unmemorable.   |
-| 127  | [Orb of Ignus](#orb-of-ignus)                               | You control a floating ball of fire (1d8 damage) for a short while. |
-| 128  | [Orb of Immortality](#orb-of-immortality)                   | Mundane attacks cannot harm anyone within a 10ft radius, or vice-versa. |
-| 129  | [Otherwordly Pet](#otherwordly-pet)                         | Summons an unintelligent extraplanar creature up to the size of a small dog. It holds no loyalty towards you or your allies. |
-| 130  | [Otherworldly Gate](#otherworldly-gate)                     | Opens a portal to another reality. It works in both directions. |
-| 131  | [Paincurrent](#paincurrent)                                 | An arc of electricity passes from your fingertips to a target you touch. They take 1d8 damage (1d12 if wearing metal armor). |
-| 132  | [Passage](#passage)                                         | Creates a temporary passage through wood, stone or brick.    |
-| 133  | [Passive Invisibility](#passive-invisibility)               | Target is invisible until they attempt harm.                 |
-| 134  | [Peeping Warlock](#peeping-warlock)                         | You control a pair of floating eyes so long as yours remain closed. |
-| 135  | [Perfect Illusion](#perfect-illusion)                       | Creates an image with sound, smell and thermal effects, activated according to a trigger you choose. Touching the image or making a successful WIL save will reveal the illusion. |
-| 136  | [Perfect Preservation](#perfect-preservation)               | A weapon you touch becomes immune to wear, mundane damage or elemental effects. The spell wears off after a day. |
-| 137  | [Phantom Hound](#phantom-hound)                             | A ghostly canine (4 HP, bite (1d4)) obeys your commands for up to one hour. |
-| 138  | [Phase Anchor](#phase-anchor)                               | Binds an extraplanar creature to your will until it performs a task specific task, after which they must pass a WIL save to escape (good luck). |
-| 139  | [Phase Sneak](#phase-sneak)                                 | Anyone within a 10ft radius is rendered invisible.           |
-| 140  | [Phase Touch](#phase-touch)                                 | A disembodied, floating hand obeys your whims but is immaterial. The next Spellbook, ability or item that relies on touch now works from a distance. |
-| 141  | [Philolomancy](#philolomancy)                               | You understand all spoken and written languages.             |
-| 142  | [Planal Metamorphosis](#planal-metamorphosis)               | Invisible creatures or objects are revealed.                 |
-| 143  | [Planar Anchor](#planar-anchor)                             | Bars extradimensional movement.                              |
-| 144  | [Plant Scourge](#plant-scourge)                             | Plants within eyesight wither and die.                       |
-| 145  | [Pocket Container](#pocket-container)                       | Summons a chest from an immaterial plane. It holds up to 6 items. The chest is dismissed at will. |
-| 146  | [Pocket Sun](#pocket-sun)                                   | You create a halo of bright light in a 60ft radius.          |
-| 147  | [Prisma Shard](#prisma-shard)                               | An array of hypnotic lights fascinate nearby creatures, unless they pass a WIL save. |
-| 148  | [Profane Reveal](#profane-reveal)                           | Target must WIL save or its attacks are impaired. Target an empty space to reveal invisible objects or creatures. |
-| 149  | [Psychic Eye](#psychic-eye)                                 | Invisible floating eye allowing you to observe a single location as present. |
-| 150  | [Psychokinesis](#psychokinesis)                             | Magically moves an object up to half your weight.            |
-| 151  | [Puppeteer](#puppeteer)                                     | You can throw your voice a great distance away               |
-| 152  | [Purge Text](#purge-text)                                   | Mundane or magical writing vanishes at your touch.           |
-| 153  | [Pyramid of Passivity](#pyramid-of-passivity)               | Target creatures must make a DEX save or their attacks are impaired. |
-| 154  | [Pyschic Touch](#pyschic-touch)                             | You can hear target's surface thoughts, so long as you touch them. |
-| 155  | [Rat-Tat-Tat](#rat-tat-tat)                                 | Loudly opens a locked or magically sealed door or chest.     |
-| 156  | [Ravenless Message](#ravenless-message)                     | You send a short message 1 mile that anyone along its path can hear. |
-| 157  | [Reject Unlife](#reject-unlife)                             | Nearby undead are immobilized for 30 seconds or until you take another action. |
-| 158  | [Remembered Voice](#remembered-voice)                       | A spot you mark becomes the trigger for a supernatural recording of your voice, delivering a short message of your choice. |
-| 159  | [Reverie](#reverie)                                         | Targets become dazed for a moment, as if lost in daydream.   |
-| 160  | [Runic Harm](#runic-harm)                                   | A rune you draw causes great pain to the reader, who must WIL save or scream until they pass out (1d4 WIL loss). A successful save destroys the rune. |
-| 161  | [Runic Slumber](#runic-slumber)                             | A rune you draw puts the reader into a magical sleep that lasts 1d6 hours. |
-| 162  | [Safe Haven](#safe-haven)                                   | You summon a floating, invisible refuge for 8 hours. It fits up to 8 people comfortably. |
-| 163  | [Scintillate](#scintillate)                                 | Target must WIL save or their attacks become impaired.       |
-| 164  | [Scry Creature](#scry-creature)                             | Indicates the precise location of a familiar creature.       |
-| 165  | [Scry Object](#scry-object)                                 | Indicates the precise location of an object, known or otherwise. |
-| 166  | [Scrying Ward](#scrying-ward)                               | For 24 hours you become aware of any magical eavesdropping.  |
-| 167  | [Sculpt Water](#sculpt-water)                               | Raise, lower or part nearby water.                           |
-| 168  | [Secret Attaché](#secret-attaché)                           | You summon an invisible creature of great power that obeys your every command. Reading from other Spellbooks dispels the creature. |
-| 169  | [Shelter](#shelter)                                         | Creates a standing edifice that can shelter up to 10 creatures, disappearing after 24 hours. |
-| 170  | [Shrinking Cant](#shrinking-cant)                           | A humanoid creature you touch halves in size.                |
-| 171  | [Signal](#signal)                                           | Sends up a flare that can be seen for some distance.         |
-| 172  | [Simple Illusion](#simple-illusion)                         | Creates a simple image with sound. A cursory investigation will reveal the illusory image. |
-| 173  | [Sinister Flame](#sinister-flame)                           | Target's palms are lined with flames (1d4+1 STR loss) for one minute. |
-| 174  | [Sinister Polymorph](#sinister-polymorph)                   | WIL save or target is transformed into a harmless animal.    |
-| 175  | [Skillfull Repair](#skillfull-repair)                       | You make minor repairs to a nonliving object.                |
-| 176  | [Sky Raft](#sky-raft)                                       | You summon a 3ft wide floating disk that holds up to 100lbs. |
-| 177  | [Solar Portal](#solar-portal)                               | Sends an extraplanar message to all beings that wish to enter your plane. You have no choice which being answers and it holds no loyalty to you or your allies. |
-| 178  | [Song of Repose](#song-of-repose)                           | Target falls into a deep slumber.                            |
-| 179  | [Sonic Shattering](#sonic-shattering)                       | A sonic wave causes 1d6 STR loss to susceptible objects or crystalline creatures, ignoring armor. |
-| 180  | [Sorcerer's Lock](#sorcerers-lock)                          | Any door (magical or otherwise) is held shut until you leave its vicinity. |
-| 181  | [Soul Annex](#soul-annex)                                   | Target's spirit is caged within their body and replaced with the caster's. If the body is slain the original soul departs, but the caster must pass a WIL save to return to their body. |
-| 182  | [Steer's Strength](#steers-strength)                        | Target's strength triples; unarmed attacks are enhanced.     |
-| 183  | [Strength Tap](#strength-tap)                               | A target you touch loses 1d6 STR, which is transferred to you (up to your max STR). |
-| 184  | [Stumbling Steps](#stumbling-steps)                         | A target you touch becomes deprived and loses 1 STR.         |
-| 185  | [Stupefaction](#stupefaction)                               | Target temporarily loses sense of place and time. WIL save to overcome. |
-| 186  | [Sudden Slumber](#sudden-slumber)                           | Target falls asleep for 1d4 hours.                           |
-| 187  | [Summon Elemental](#summon-elemental)                       | A being of fire, wire, earth, or wind manifests from available matter to perform a single task for the caster. It follows this command against its will. |
-| 188  | [Sway Will](#sway-will)                                     | A target is compelled to follow a stated course of action, without understanding why. |
-| 189  | [Temporary Reprieve](#temporary-reprieve)                   | Target regains any lost STR, but loses it again after a few minutes. |
-| 190  | [Terrify](#terrify)                                         | Targets within eyesight must pass a WIL save or flee.        |
-| 191  | [Terrifying Illusion](#terrifying-illusion)                 | A target is hunted by a terrible creature only they can see. Its attacks do 1d12 damage; on Critical Damage they must pass a WIL save or become catatonic. |
-| 192  | [Thief's Bane](#thiefs-bane)                                | An object appears trapped, even to an experienced thief.     |
-| 193  | [Thwart the Elements](#thwart-the-elements)                 | Damage from energy blasts are impaired against a target for the next hour. |
-| 194  | [Tongue of the Blue Serpent](#tongue-of-the-blue-serpent)   | Rust-colored, serpentine letters materialize on a surface you choose. Anyone reading these words becomes immobilized unless they succeed a WIL save. |
-| 195  | [Torrential Moat](#torrential-moat)                         | You summon a powerful wind that deflects arrows, smaller creatures, and noxious gases. |
-| 196  | [Toxic Blast](#toxic-blast)                                 | A small orb of acid deals 1d6 blast damage to a target.      |
-| 197  | [Transform Aura](#transform-aura)                           | Target's aura is made non-magical or vice-versa.             |
-| 198  | [True Name](#true-name)                                     | Determines the properties of a magical item you touch.       |
-| 199  | [Trueshift](#trueshift)                                     | A willing target takes on a new form (keeping only their WIL), but must pass a WIL save to shift out. |
-| 200  | [Twilight Steed](#twilight-steed)                           | Summons an arcane steed that never tires, but dissipates within daylight. |
-| 201  | [Ultimate Sacrifice](#ultimate-sacrifice)                   | The book's holder transfer's their life force into a corpse, reviving both body and soul. |
-| 202  | [Uncurse](#uncurse)                                         | A person or object you touch is freed from a curse or nefarious spell. |
-| 203  | [Undefinable Target](#undefinable-target)                   | An ally becomes immune to mundane ranged attacks for one round. |
-| 204  | [Undeniable Courage](#undeniable-courage)                   | Target passes next WIL save and their attacks are enhanced.  |
-| 205  | [Unflappable Endurance](#unflappable-endurance)             | Target does not take Fatigue from non-magical activities or become deprived until their next rest. |
-| 206  | [Vermin Plague](#vermin-plague)                             | Summons a swarm of bats, rats, spiders or similar creatures of your choice. They are harmless but distracting and hold no loyalty towards you or your allies. |
-| 207  | [Vines of Ichor](#vines-of-ichor)                           | You spread sticky spiderwebs on the walls, floor and ceilings within a 20ft radius. |
-| 208  | [Warrior's Edge](#warriors-edge)                            | Target weapon is enhanced, and victim automatically fails a critical damage save. |
-| 209  | [Windborn](#windborn)                                       | You direct a powerful wind in a straight line, strong enough to blow over small boulders. |
-| 210  | [Winter's Woe](#winters-woe)                                | An icy storm assails multiple targets, obscuring visibility and making the ground icy and treacherous. |
-| 211  | [Witch Sight](#witch-sight)                                 | Magical auras become visible to you for one hour.            |
-| 212  | [Wizard's Exit](#wizards-exit)                              | You and and anyone you touch can flee to safety at double speed. |
-| 213  | [Wizard's Grasp](#wizards-grasp)                            | You control a phantasmal hand that can lift up to 5 pounds.  |
-| 214  | [Wizard's Haven](#wizards-haven)                            | A small, walled-in area cannot be scryed.                    |
-| 215  | [Wizardsniff](#wizardsniff)                                 | You can feel any magic within a 60ft radius.                 |
-| 216  | [Word of Pain](#word-of-pain)                               | A single phrase from your lips does 1d12 blast damage. Affected targets are also deafened. |
+| 111  | [Adaptive Skin](#adaptive-skin)                             | Target can exist comfortably in hot or cold environments.    |
+| 112  | [Addle Brain](#addle-brain)                                 | Target must pass WIL save or drop to 0 WIL for 1 hour.       |
+| 113  | [Animal Call](#animal-call)                                 | Summons a mundane beast. It holds no loyalty towards you or your allies. |
+| 114  | [Anti-Magic Globe](#anti-magic-globe)                       | A thin shell of magical protection surrounds a small area around the caster. For every additional minute the globe is active they take one additional Fatigue. |
+| 115  | [Arachnid's Finesse](#arachnids-finesse)                    | Target can walk on walls and ceilings.                       |
+| 116  | [Arcane Arrow](#arcane-arrow)                               | Green energy bursts from your fingers, dealing 1d6 damage and ignoring mundane armor. |
+| 121  | [Arcane Confinement](#arcane-confinement)                   | Target is bound by magical rope, able only to speak but nothing more. |
+| 122  | [Arcane Epistle](#arcane-epistle)                           | You write a letter that only its intended reader can understand. |
+| 123  | [Arcane Fireworks](#arcane-fireworks)                       | Target flame becomes a great conflagration of heat, light and sound. |
+| 124  | [Arcane Stain](#arcane-stain)                               | Inscribes an invisible rune you can feel. Suffer 1d4 WIL loss if removed. |
+| 125  | [Architect's Eye](#architects-eye)                          | Any hidden doors within 60ft light up as if on fire.         |
+| 126  | [Architect's Perfection](#architects-perfection)            | Create a holographic wall, floor, or ceiling that looks absolutely real. |
+| 131  | [Astral Step](#astral-step)                                 | You and anyone touching you instantly transport to a known location you have been to before. |
+| 132  | [Banishment](#banishment)                                   | WIL save or creature to returns to native plane.             |
+| 133  | [Become Unseen](#become-unseen)                             | Target becomes invisible for 1 hour, and are still able use abilities and attack without detection. Afterwards they become incapacitated (deprived) |
+| 134  | [Beguilement](#beguilement)                                 | Target humanoid must make a WIL save or is controlled telepathically. |
+| 135  | [Bewildering Fog](#bewildering-fog)                         | A hazy fog surrounds you in a radius of 20ft. Attacks within the mist are impaired. |
+| 136  | [Blazing Defense](#blazing-defense)                         | You manifest a shield of flame (+1 Armor, 1d6 damage). Fire cannot hurt you. |
+| 141  | [Blessing](#blessing)                                       | Target’s attacks are enhanced and non-Blast attacks are impaired against them until they next take damage. |
+| 142  | [Bolster](#bolster)                                         | A person you can see is emboldened by your words for a few minutes: their attacks are enhanced and they cannot become deprived. |
+| 143  | [Bound](#bound)                                             | Target can make a single jump to any place they can see.     |
+| 144  | [Boundless Message](#boundless-message)                     | Delivers a single sentence to any one creature instantaneously, no matter the distance. |
+| 145  | [Breath Soup](#breath-soup)                                 | Blocks vision and slows movement.                            |
+| 146  | [Burning Missile](#burning-missile)                         | You fire an acid missile that does 1d6 damage to a target for every round it is not washed off. |
+| 151  | [Burnishing Bubble](#burnishing-bubble)                     | Target is enclosed by an impenetrable sphere that rolls along the ground, unless they pass a DEX save. |
+| 152  | [Calcify](#calcify)                                         | Target object turns to stone at the caster's touch. Living targets save vs STR. |
+| 153  | [Catsense](#catsense)                                       | Target has heightened senses for the next hour, especially at night. |
+| 154  | [Chilling Graze](#chilling-graze)                           | Target loses 1d4+1 STR and is deprived.                      |
+| 155  | [Cinder Flesh](#cinder-flesh)                               | Energy beams burn enemies (1d10 blast damage) in a straight line. |
+| 156  | [Circle of Arcane Protection](#circle-of-arcane-protection) | Magical or godly beings cannot enter a 10ft circle.          |
+| 161  | [Cleanse](#cleanse)                                         | Rotten or poisoned food becomes edible.                      |
+| 162  | [Cold Spray](#cold-spray)                                   | A spray of cold air does d6 damage 20ft in one direction.    |
+| 163  | [Conceal Object](#conceal-object)                           | Masks an object against divination or scrying.               |
+| 164  | [Conquer Gravity](#conquer-gravity)                         | Target moves up or down according to your whims.             |
+| 165  | [Cosmic Fingertips](#cosmic-fingertips)                     | Your hands sculpt stone, rock or minerals into any form you please. |
+| 166  | [Coup de Grâce](#coup-de-grâce)                             | An ally's next attack ignores armor and takes damage directly from their target's STR. |
+| 211  | [Craft from Clay](#craft-from-clay)                         | Any natural, earthen target is transformed (rock to mud, lava to rock, etc). |
+| 212  | [Create Unlife](#create-unlife)                             | Creates 1d4 undead skeletons and zombies from corpses. WIL save every hour to control them. |
+| 213  | [Curse of the Sightless](#curse-of-the-sightless)           | Anyone within eyesight must make a WIL save or be blinded.   |
+| 214  | [Curse Unlife](#curse-unlife)                               | Deals 1d4+2 STR loss to one undead, ignoring armor and resistances. |
+| 215  | [Cure-All](#cure-all)                                       | A single illness or disease dissipates at your touch.        |
+| 216  | [Cute Ink](#cute-ink)                                       | A single page in a book can be altered to hide its true content. |
+| 221  | [Darksight](#darksight)                                     | Target can see 60 ft. in total darkness.                     |
+| 222  | [Death's Breath](#deaths-breath)                            | You summon a poisonous cloud (d6 STR loss) you can control.  |
+| 223  | [Devil's Comedian](#devils-comedian)                        | WIL save or target laughs uncontrollably, unable to take any action. |
+| 224  | [Disaster Fluid](#disaster-fluid)                           | Anything in a 10ft square becomes slippery; DEX save to avoid slipping. |
+| 225  | [Disrupt Scry](#disrupt-scry)                               | Future divinations of one creature or object are misled according to your will. |
+| 226  | [Doppleganger](#doppleganger)                               | You spawn 1d6 decoy duplicates of someone you touch. Decoys are dispelled with a touch. |
+| 231  | [Doubleskin](#doubleskin)                                   | Target humanoid doubles in size.                             |
+| 232  | [Dreampoison](#dreampoison)                                 | Target is deprived after suffering a night of bad dreams.    |
+| 233  | [Dreamtalker](#dreamtalker)                                 | Sends a message to anyone currently asleep.                  |
+| 234  | [Earsplit](#earsplit)                                       | Anyone within earshot is deafened.                           |
+| 235  | [Easy Descent](#easy-descent)                               | Objects or creatures nearby fall very slowly.                |
+| 236  | [Edifice](#edifice)                                         | You summon a stone wall up to 20ft wide that you can control. |
+| 241  | [Energize Rope](#energize-rope)                             | A rope-like objects moves at your command.                   |
+| 242  | [Ensorcelled](#ensorcelled)                                 | Creatures are enraptured for a few minutes unless they pass a WIL save. |
+| 243  | [Envision](#envision)                                       | Spies on a target you have met, even across vast distances. On a WIL save, they can feel your presence. |
+| 244  | [Ephemeral Audio](#ephemeral-audio)                         | Point to a spot. Anyone nearby hears a sound you choose at any volume. |
+| 245  | [Epidemic](#epidemic)                                       | Infects target with disease, which spreads until the source of magic is destroyed. |
+| 246  | [Extraplanar Convocation](#extraplanar-convocation)         | Summons any extraplanar being onto your plane. It holds no loyalty towards you or your allies. |
+| 251  | [Extraplanar Request](#extraplanar-request)                 | Ask a single question of a random extraplanar entity.        |
+| 252  | [Feline Dexterity](#feline-dexterity)                       | Target becomes limber, lithe and as fast as quicksilver.     |
+| 253  | [Find Virulence](#find-virulence)                           | Detects poison in any creature or object within 30ft.        |
+| 254  | [Fire Curse](#fire-curse)                                   | An object you touch is imbued with a hidden flame-trap dealing 1d4+2 STR loss. |
+| 255  | [Firey Missile](#firey-missile)                             | A bow you touch can fire flaming arrows (1d10 damage) for one minute. |
+| 256  | [Fish Lung](#fish-lung)                                     | A target can breathe underwater until they surface again.    |
+| 261  | [Fleetfooted](#fleetfooted)                                 | One creature moves at double speed.                          |
+| 262  | [Flicker](#flicker)                                         | Target randomly vanishes and reappears once at will.         |
+| 263  | [Fog of Nausea](#fog-of-nausea)                             | A cloud of nauseating vapors pours out from the Spellbook's pages. Anyone nearby makes a STR save or vomit uncontrollably. |
+| 264  | [Fold Portal](#fold-portal)                                 | A door you touch opens into another door you've stepped through before until it is shut again. |
+| 265  | [Foolishness](#foolishness)                                 | A target you touch becomes vulnerable to wild mood swings, sweeping conclusions and silly behavior. They also lose 1d6 WIL for 24 hours (down to a minimum of 1). |
+| 266  | [Fortify](#fortify)                                         | Damage from heat, ice, acid or electricity are impaired against a target for the next hour. |
+| 311  | [Frozen Corpse](#frozen-corpse)                             | A corpse you touch is preserved.                             |
+| 312  | [Gale](#gale)                                               | You summon an impenetrable wall of energy up to 15ft wide.   |
+| 313  | [Ghost Whisper](#ghost-whisper)                             | You and a sympathetic ally are linked, able to converse in short sentences for an hour. |
+| 314  | [Gift of Flight](#gift-of-flight)                           | Target can fly for a short while.                            |
+| 315  | [Glacier](#glacier)                                         | You create a wall of ice (15 HP, 3 Armor) around a creature you choose. |
+| 316  | [Gorgon's Gaze](#gorgons-gaze)                              | Target is transformed into a statue on a failed WIL save. A success reverses the spell; holder must pass a WIL save or the book is destroyed. |
+| 321  | [Great Ball of Fire](#great-ball-of-fire)                   | You fire a ball of flame (1d10 damage) up to 20 feet away.   |
+| 322  | [Hand of the Protector](#hand-of-the-protector)             | A giant, floating hand blocks all damage from a single opponent until you are safe from danger. |
+| 323  | [Healing Grace](#healing-grace)                             | A target heals 1d6 STR, and you become deprived until you take the time to mediate, pray or sleep. |
+| 324  | [Heatless Torch](#heatless-torch)                           | Turns any object into a permanent, heatless torch.           |
+| 325  | [Hedgemagick](#hedgemagick)                                 | You perform a minor magical trick (create flame, wind, light or sound). |
+| 326  | [Hempen Hoop](#hempen-hoop)                                 | A rope moves at your command.                                |
+| 331  | [Hide Mind](#hide-mind)                                     | The next person to scry your mind or your whereabouts is fooled. |
+| 332  | [Hoodwink Monster](#hoodwink-monster)                       | Target monster makes a WIL save or treats you as an ally.    |
+| 333  | [Hoodwink Person](#hoodwink-person)                         | Target becomes a friend until out of sight.                  |
+| 334  | [Hovering Protection](#hovering-protection)                 | A hovering, transparent disk materializes around an ally granting 1 Armor. |
+| 335  | [Ice Ray](#ice-ray)                                         | Ice and snow flow from your fingerprints, dealing 1d8 damage (blast) in a straight line. |
+| 336  | [Icy Tempest](#icy-tempest)                                 | Hail deals 1d12 damage in a 20ft radius.                     |
+| 341  | [Ill Fate](#ill-fate)                                       | Target automatically fails next their next save.             |
+| 342  | [Illusory Landscape](#illusory-landscape)                   | You can make one type of terrain appear like another.        |
+| 343  | [Incorporeal Shrug](#incorporeal-shrug)                     | Ignore any one attack.                                       |
+| 344  | [Induce Despair](#induce-despair)                           | Target must pass a WIL save or its attacks are impaired.     |
+| 345  | [Induce Horror](#induce-horror)                             | Target makes a WIL save or flees.                            |
+| 346  | [Inferno](#inferno)                                         | You summon a flaming wall up to 15ft wide. Anyone passing through suffers 1d6 STR loss. |
+| 351  | [Influence](#influence)                                     | Target gains armor 3 but running and swimming are impossible. |
+| 352  | [Insubstantiate](#insubstantiate)                           | Target becomes insubstantial and can float.                  |
+| 353  | [Kraken's Curse](#krakens-curse)                            | Tentacles grapple all within 20 ft, STR save to break free.  |
+| 354  | [Lamp's Hue](#lamps-hue)                                    | Target object shines like a torch for one hour.              |
+| 355  | [Latch](#latch)                                             | An unlocked box, cabinet or door opens or closes at your command. |
+| 356  | [Librarian's Trap](#librarians-trap)                        | Deals 1d4+2 STR loss when read.                              |
+| 361  | [Lichsense](#lichsense)                                     | You feel any undead within 60ft. WIL save to avoid detection by intelligent undead. |
+| 362  | [Light Show](#light-show)                                   | You control a dazzling display of light and color.           |
+| 363  | [Lightning Strike](#lightning-strike)                       | Electricity flings from your fingertips doing 1d12 damage (blast) in a line. |
+| 364  | [Linguist](#linguist)                                       | For the next hour you can speak and understand any mundane language. |
+| 365  | [Magic Seal](#magic-seal)                                   | Magically locks a door, portal or chest.                     |
+| 366  | [Major Genesis](#major-genesis)                             | Creates an object of nonliving stone or metal no greater than 5 cubic foot in size. |
+| 411  | [Maker](#maker)                                             | Transforms raw materials into finished items.                |
+| 412  | [Manic Fury](#manic-fury)                                   | A target's attacks are enhanced. They must make a WIL save after a successful killing or lose control, attacking anyone in sight. |
+| 413  | [Masquerade](#masquerade)                                   | You assume the likeness of a similar creature you have seen. |
+| 414  | [Master Undead](#master-undead)                             | Undead creatures obey your command. Intelligent undead make a WIL save. |
+| 415  | [Mental Tripwire](#mental-tripwire)                         | Intruders set off an alarm audible only to you.              |
+| 416  | [Mind Bond](#mind-bond)                                     | Two allies can communicate via a mental link for the rest of the day. |
+| 421  | [Mind Reader](#mind-reader)                                 | You can see or hear any person you have met before.          |
+| 422  | [Miniaturize](#miniaturize)                                 | An object shrinks to one tenth its size.                     |
+| 423  | [Minor Aegis](#minor-aegis)                                 | A target you touch ignores the next instance of harm from a specific source. |
+| 424  | [Minor Genesis](#minor-genesis)                             | Creates an object of nonliving matter no greater than one cubic foot in size. |
+| 425  | [Mirage](#mirage)                                           | You summon a noiseless & simple illusion of your choice.     |
+| 426  | [Molasses Veins](#molasses-veins)                           | A single target moves at half speed.                         |
+| 431  | [Murky Bubble](#murky-bubble)                               | You create a bubble supernatural shadow within a 20ft radius. |
+| 432  | [Necrotic Touch](#necrotic-touch)                           | Target must DEX save or is paralyzed.                        |
+| 433  | [Obfuscate](#obfuscate)                                     | Target cannot be observed either through divination or scrying. |
+| 434  | [Obfuscation](#obfuscation)                                 | Changes your appearance.                                     |
+| 435  | [Obscuring Mist](#obscuring-mist)                           | A rolling fog obscures vision in a 300ft radius.             |
+| 436  | [Opaque Cover](#opaque-cover)                               | Details about your person become obscured and unmemorable.   |
+| 441  | [Orb of Ignus](#orb-of-ignus)                               | You control a floating ball of fire (1d8 damage) for a short while. |
+| 442  | [Orb of Immortality](#orb-of-immortality)                   | Mundane attacks cannot harm anyone within a 10ft radius, or vice-versa. |
+| 443  | [Otherwordly Pet](#otherwordly-pet)                         | Summons an unintelligent extraplanar creature up to the size of a small dog. It holds no loyalty towards you or your allies. |
+| 444  | [Otherworldly Gate](#otherworldly-gate)                     | Opens a portal to another reality. It works in both directions. |
+| 445  | [Paincurrent](#paincurrent)                                 | An arc of electricity passes from your fingertips to a target you touch. They take 1d8 damage (1d12 if wearing metal armor). |
+| 446  | [Passage](#passage)                                         | Creates a temporary passage through wood, stone or brick.    |
+| 451  | [Passive Invisibility](#passive-invisibility)               | Target is invisible until they attempt harm.                 |
+| 452  | [Peeping Warlock](#peeping-warlock)                         | You control a pair of floating eyes so long as yours remain closed. |
+| 453  | [Perfect Illusion](#perfect-illusion)                       | Creates an image with sound, smell and thermal effects, activated according to a trigger you choose. Touching the image or making a successful WIL save will reveal the illusion. |
+| 454  | [Perfect Preservation](#perfect-preservation)               | A weapon you touch becomes immune to wear, mundane damage or elemental effects. The spell wears off after a day. |
+| 455  | [Phantom Hound](#phantom-hound)                             | A ghostly canine (4 HP, bite (1d4)) obeys your commands for up to one hour. |
+| 456  | [Phase Anchor](#phase-anchor)                               | Binds an extraplanar creature to your will until it performs a task specific task, after which they must pass a WIL save to escape (good luck). |
+| 461  | [Phase Sneak](#phase-sneak)                                 | Anyone within a 10ft radius is rendered invisible.           |
+| 462  | [Phase Touch](#phase-touch)                                 | A disembodied, floating hand obeys your whims but is immaterial. The next Spellbook, ability or item that relies on touch now works from a distance. |
+| 463  | [Philolomancy](#philolomancy)                               | You understand all spoken and written languages.             |
+| 464  | [Planal Metamorphosis](#planal-metamorphosis)               | Invisible creatures or objects are revealed.                 |
+| 465  | [Planar Anchor](#planar-anchor)                             | Bars extradimensional movement.                              |
+| 466  | [Plant Scourge](#plant-scourge)                             | Plants within eyesight wither and die.                       |
+| 511  | [Pocket Container](#pocket-container)                       | Summons a chest from an immaterial plane. It holds up to 6 items. The chest is dismissed at will. |
+| 512  | [Pocket Sun](#pocket-sun)                                   | You create a halo of bright light in a 60ft radius.          |
+| 513  | [Prisma Shard](#prisma-shard)                               | An array of hypnotic lights fascinate nearby creatures, unless they pass a WIL save. |
+| 514  | [Profane Reveal](#profane-reveal)                           | Target must WIL save or its attacks are impaired. Target an empty space to reveal invisible objects or creatures. |
+| 515  | [Psychic Eye](#psychic-eye)                                 | Invisible floating eye allowing you to observe a single location as present. |
+| 516  | [Psychokinesis](#psychokinesis)                             | Magically moves an object up to half your weight.            |
+| 521  | [Puppeteer](#puppeteer)                                     | You can throw your voice a great distance away               |
+| 522  | [Purge Text](#purge-text)                                   | Mundane or magical writing vanishes at your touch.           |
+| 523  | [Pyramid of Passivity](#pyramid-of-passivity)               | Target creatures must make a DEX save or their attacks are impaired. |
+| 524  | [Pyschic Touch](#pyschic-touch)                             | You can hear target's surface thoughts, so long as you touch them. |
+| 525  | [Rat-Tat-Tat](#rat-tat-tat)                                 | Loudly opens a locked or magically sealed door or chest.     |
+| 526  | [Ravenless Message](#ravenless-message)                     | You send a short message 1 mile that anyone along its path can hear. |
+| 531  | [Reject Unlife](#reject-unlife)                             | Nearby undead are immobilized for 30 seconds or until you take another action. |
+| 532  | [Remembered Voice](#remembered-voice)                       | A spot you mark becomes the trigger for a supernatural recording of your voice, delivering a short message of your choice. |
+| 533  | [Reverie](#reverie)                                         | Targets become dazed for a moment, as if lost in daydream.   |
+| 534  | [Runic Harm](#runic-harm)                                   | A rune you draw causes great pain to the reader, who must WIL save or scream until they pass out (1d4 WIL loss). A successful save destroys the rune. |
+| 535  | [Runic Slumber](#runic-slumber)                             | A rune you draw puts the reader into a magical sleep that lasts 1d6 hours. |
+| 536  | [Safe Haven](#safe-haven)                                   | You summon a floating, invisible refuge for 8 hours. It fits up to 8 people comfortably. |
+| 541  | [Scintillate](#scintillate)                                 | Target must WIL save or their attacks become impaired.       |
+| 542  | [Scry Creature](#scry-creature)                             | Indicates the precise location of a familiar creature.       |
+| 543  | [Scry Object](#scry-object)                                 | Indicates the precise location of an object, known or otherwise. |
+| 544  | [Scrying Ward](#scrying-ward)                               | For 24 hours you become aware of any magical eavesdropping.  |
+| 545  | [Sculpt Water](#sculpt-water)                               | Raise, lower or part nearby water.                           |
+| 546  | [Secret Attaché](#secret-attaché)                           | You summon an invisible creature of great power that obeys your every command. Reading from other Spellbooks dispels the creature. |
+| 551  | [Shelter](#shelter)                                         | Creates a standing edifice that can shelter up to 10 creatures, disappearing after 24 hours. |
+| 552  | [Shrinking Cant](#shrinking-cant)                           | A humanoid creature you touch halves in size.                |
+| 553  | [Signal](#signal)                                           | Sends up a flare that can be seen for some distance.         |
+| 554  | [Simple Illusion](#simple-illusion)                         | Creates a simple image with sound. A cursory investigation will reveal the illusory image. |
+| 555  | [Sinister Flame](#sinister-flame)                           | Target's palms are lined with flames (1d4+1 STR loss) for one minute. |
+| 556  | [Sinister Polymorph](#sinister-polymorph)                   | WIL save or target is transformed into a harmless animal.    |
+| 561  | [Skillfull Repair](#skillfull-repair)                       | You make minor repairs to a nonliving object.                |
+| 562  | [Sky Raft](#sky-raft)                                       | You summon a 3ft wide floating disk that holds up to 100lbs. |
+| 563  | [Solar Portal](#solar-portal)                               | Sends an extraplanar message to all beings that wish to enter your plane. You have no choice which being answers and it holds no loyalty to you or your allies. |
+| 564  | [Song of Repose](#song-of-repose)                           | Target falls into a deep slumber.                            |
+| 565  | [Sonic Shattering](#sonic-shattering)                       | A sonic wave causes 1d6 STR loss to susceptible objects or crystalline creatures, ignoring armor. |
+| 566  | [Sorcerer's Lock](#sorcerers-lock)                          | Any door (magical or otherwise) is held shut until you leave its vicinity. |
+| 611  | [Soul Annex](#soul-annex)                                   | Target's spirit is caged within their body and replaced with the caster's. If the body is slain the original soul departs, but the caster must pass a WIL save to return to their body. |
+| 612  | [Steer's Strength](#steers-strength)                        | Target's strength triples; unarmed attacks are enhanced.     |
+| 613  | [Strength Tap](#strength-tap)                               | A target you touch loses 1d6 STR, which is transferred to you (up to your max STR). |
+| 614  | [Stumbling Steps](#stumbling-steps)                         | A target you touch becomes deprived and loses 1 STR.         |
+| 615  | [Stupefaction](#stupefaction)                               | Target temporarily loses sense of place and time. WIL save to overcome. |
+| 616  | [Sudden Slumber](#sudden-slumber)                           | Target falls asleep for 1d4 hours.                           |
+| 621  | [Summon Elemental](#summon-elemental)                       | A being of fire, wire, earth, or wind manifests from available matter to perform a single task for the caster. It follows this command against its will. |
+| 622  | [Sway Will](#sway-will)                                     | A target is compelled to follow a stated course of action, without understanding why. |
+| 623  | [Temporary Reprieve](#temporary-reprieve)                   | Target regains any lost STR, but loses it again after a few minutes. |
+| 624  | [Terrify](#terrify)                                         | Targets within eyesight must pass a WIL save or flee.        |
+| 625  | [Terrifying Illusion](#terrifying-illusion)                 | A target is hunted by a terrible creature only they can see. Its attacks do 1d12 damage; on Critical Damage they must pass a WIL save or become catatonic. |
+| 626  | [Thief's Bane](#thiefs-bane)                                | An object appears trapped, even to an experienced thief.     |
+| 631  | [Thwart the Elements](#thwart-the-elements)                 | Damage from energy blasts are impaired against a target for the next hour. |
+| 632  | [Tongue of the Blue Serpent](#tongue-of-the-blue-serpent)   | Rust-colored, serpentine letters materialize on a surface you choose. Anyone reading these words becomes immobilized unless they succeed a WIL save. |
+| 633  | [Torrential Moat](#torrential-moat)                         | You summon a powerful wind that deflects arrows, smaller creatures, and noxious gases. |
+| 634  | [Toxic Blast](#toxic-blast)                                 | A small orb of acid deals 1d6 blast damage to a target.      |
+| 635  | [Transform Aura](#transform-aura)                           | Target's aura is made non-magical or vice-versa.             |
+| 636  | [True Name](#true-name)                                     | Determines the properties of a magical item you touch.       |
+| 641  | [Trueshift](#trueshift)                                     | A willing target takes on a new form (keeping only their WIL), but must pass a WIL save to shift out. |
+| 642  | [Twilight Steed](#twilight-steed)                           | Summons an arcane steed that never tires, but dissipates within daylight. |
+| 643  | [Ultimate Sacrifice](#ultimate-sacrifice)                   | The book's holder transfer's their life force into a corpse, reviving both body and soul. |
+| 644  | [Uncurse](#uncurse)                                         | A person or object you touch is freed from a curse or nefarious spell. |
+| 645  | [Undefinable Target](#undefinable-target)                   | An ally becomes immune to mundane ranged attacks for one round. |
+| 646  | [Undeniable Courage](#undeniable-courage)                   | Target passes next WIL save and their attacks are enhanced.  |
+| 651  | [Unflappable Endurance](#unflappable-endurance)             | Target does not take Fatigue from non-magical activities or become deprived until their next rest. |
+| 652  | [Vermin Plague](#vermin-plague)                             | Summons a swarm of bats, rats, spiders or similar creatures of your choice. They are harmless but distracting and hold no loyalty towards you or your allies. |
+| 653  | [Vines of Ichor](#vines-of-ichor)                           | You spread sticky spiderwebs on the walls, floor and ceilings within a 20ft radius. |
+| 654  | [Warrior's Edge](#warriors-edge)                            | Target weapon is enhanced, and victim automatically fails a critical damage save. |
+| 655  | [Windborn](#windborn)                                       | You direct a powerful wind in a straight line, strong enough to blow over small boulders. |
+| 656  | [Winter's Woe](#winters-woe)                                | An icy storm assails multiple targets, obscuring visibility and making the ground icy and treacherous. |
+| 661  | [Witch Sight](#witch-sight)                                 | Magical auras become visible to you for one hour.            |
+| 662  | [Wizard's Exit](#wizards-exit)                              | You and and anyone you touch can flee to safety at double speed. |
+| 663  | [Wizard's Grasp](#wizards-grasp)                            | You control a phantasmal hand that can lift up to 5 pounds.  |
+| 664  | [Wizard's Haven](#wizards-haven)                            | A small, walled-in area cannot be scryed.                    |
+| 665  | [Wizardsniff](#wizardsniff)                                 | You can feel any magic within a 60ft radius.                 |
+| 666  | [Word of Pain](#word-of-pain)                               | A single phrase from your lips does 1d12 blast damage. Affected targets are also deafened. |
 
 
 ### References


### PR DESCRIPTION
Hi @yochaigal! I modified the 'More Spellbooks' table to have proper d666 notation so that it's a little easier to roll on the list. If you prefer the old way, no worries at all and feel free to close this.

Thanks for Cairn! <3 