### PR TITLE
Update traits

### DIFF
--- a/cairn-srd.md
+++ b/cairn-srd.md
@@ -248,12 +248,12 @@ If you would like something closer to traditional classes, refer to the list of 
 #### Skin
 
 |  |            |      |           |
-| ---- | ---------- | ---- | --------- |
-| 1    | Birthmark  | 6    | Round     |
-| 2    | Dark       | 7    | Soft      |
-| 3    | Elongated  | 8    | Tanned    |
-| 4    | Pockmarked | 9    | Tattooed  |
-| 5    | Rosy       | 10   | Weathered |
+| ---- | ---------- | ---- | ---------  |
+| 1    | Birthmark  | 6    | Pockmarked |
+| 2    | Dark       | 7    | Rosy       |
+| 3    | Oily       | 8    | Tanned     |
+| 4    | Pale       | 9    | Tattooed   |
+| 5    | Perfect    | 10   | Weathered  |
 
 #### Hair
 
@@ -269,11 +269,11 @@ If you would like something closer to traditional classes, refer to the list of 
 
 |  |           |      |          |
 | ---- | --------- | ---- | -------- |
-| 1    | Bony      | 6    | Perfect  |
-| 2    | Broken    | 7    | Rat-like |
-| 3    | Chiseled  | 8    | Sharp    |
+| 1    | Bony      | 6    | Round    |
+| 2    | Broken    | 7    | Sharp    |
+| 3    | Chiseled  | 8    | Soft     |
 | 4    | Elongated | 9    | Square   |
-| 5    | Pale      | 10   | Sunken   |
+| 5    | Ratlike   | 10   | Sunken   |
 
 #### Speech
 


### PR DESCRIPTION
I'm probably not the first person to notice stuff like "round skin" and "elongated skin" in the character generator. I think these quirky descriptions has their own charm as it leaves the reader to figure out what it means.

It appears it was inspired by Ben Milton's Knave traits. Knave's traits tables has been updated so maybe we could update the SRD in time for Cairn v2?

My suggestions:
- elongated skin->oily skin
- round skin->pale skin
- soft skin->prefect skin
- rat-like face->ratlike face (ratlike has no hyphen https://en.wiktionary.org/wiki/ratlike)
- pale face->round face
- perfect face->soft face

This is also inline with the official character generator. Having parity between the character generator and the SRD trait tables means that we are accurately generating characters that could be created through dice. https://github.com/yochaigal/cairn/blob/8ab9a4885fe65acaff7c9ad73c8b424d4b76aa33/character-generator/js/cairn_data.js#L113

This is a fairly substantial change as it affects existing print editions, online generators, and VTT modules. Happy to discuss it here or on the Cairn discord.