### PR TITLE
Fix monster formatting

### DIFF
--- a/resources/monsters/beetle-fire.md
+++ b/resources/monsters/beetle-fire.md
@@ -6,7 +6,7 @@ grand_parent: Resources
 
 # Beetle, Fire
 
-2 HP, 4 STR, 12 DEX, 6 WIL, bite(d4)
+2 HP, 4 STR, 12 DEX, 6 WIL, bite (d4)
 
 - 3’ long beetles commonly found both deep underground and buried in thick brambles. 
 - Produces a orange slime through the abdomen that lasts for several days. The productive organ is very valuable alchemists.

--- a/resources/monsters/cat-sabre-toothed-tiger.md
+++ b/resources/monsters/cat-sabre-toothed-tiger.md
@@ -6,7 +6,7 @@ grand_parent: Resources
 
 # Cat, Sabre-Toothed Tiger
 
-8 HP, STR 15, 14 DEX, 3 WIL, bite (d12), claws (d6+d6)
+8 HP, 15 STR, 14 DEX, 3 WIL, bite (d12), claws (d6+d6)
 
 - Huge, primeval cats with enormous fangs.
 - Extremely rare, generally found in regions untouched by civilization.

--- a/resources/monsters/catoblepas.md
+++ b/resources/monsters/catoblepas.md
@@ -6,7 +6,7 @@ grand_parent: Resources
 
 # Catoblepas
 
-7 HP, 1 Armor, 16 STR, 9 DEX, 13 WIL, tail(d8)
+7 HP, 1 Armor, 16 STR, 9 DEX, 13 WIL, tail (d8)
 
 - A monstrous creature with the body of a Cape buffalo, scales on its back, and the head of a wild boar. Its enormous head always points towards te ground.
 - **Paralyze**: Its stare turns a single target to stone. Moonlight reverses the effect.   

--- a/resources/monsters/scorpion-giant.md
+++ b/resources/monsters/scorpion-giant.md
@@ -6,7 +6,7 @@ grand_parent: Resources
 
 # Giant Scorpion
 
-8 HP, 2 Armor, 12 DEX, 8 MIND, claws (d10+d8) or sting (d8)
+8 HP, 2 Armor, 12 DEX, 8 WIL, claws (d10+d8) or sting (d8)
 
 - Huge arachnids, the size of a horse, with pincers and poisonous stingers. Found in drylands and caverns. Highly aggressive, normally attack on sight.
 - Immobilizes its victims with the claws, and then attack with the sting.

--- a/resources/monsters/shark-giant-white.md
+++ b/resources/monsters/shark-giant-white.md
@@ -6,7 +6,7 @@ grand_parent: Resources
 
 # Great White Shark
 
-8 HP. 14 STR, 14 DEX, 6 WIL, bite (d10+d10)
+8 HP, 14 STR, 14 DEX, 6 WIL, bite (d10+d10)
 
 - 30' long aggressive fish of a grey coloration. Dwell deep salt water, and sometimes attack smaller boats.
 - Can detect the smell of blood from many miles away.

--- a/resources/monsters/warper.md
+++ b/resources/monsters/warper.md
@@ -6,7 +6,7 @@ grand_parent: Resources
 
 # Warper
 
-8 HP, 14 DEX, 12 WILL, tentacles (d8, blast)
+8 HP, 14 DEX, 12 WIL, tentacles (d8, blast)
 
 - Large panther like predators with many edged tentacles growing out of their backs.
 - Can teleport short distances at will, which it uses to ambush prey.


### PR DESCRIPTION
Simple clean-up of some monsters' formatting. 

There also is a minor formatting inconsistency (which I didn't change and it probably is not as important) with italics on the `blast` attack property. `Chimera`, `Ape, White` and `Ankheg` all have it, rest of the monsters do not afaict.