### PR TITLE
revert forward slash replacing "test"

### DIFF
--- a/adventures/conversions/a-gathering-of-blades.md
+++ b/adventures/conversions/a-gathering-of-blades.md
@@ -32,7 +32,7 @@ redirect_from: /resources/adventure-conversions/a-gathering-of-blades/
 3 HP, 12 STR, 15 DEX, 6 WIL, bite (d8)
 
 ### The Lepidoracy
-18 HP, 16 STR, 5 DEX, 6 WIL, multi-sword-slash (d12+d12, blast)  
+18 HP, 16 STR, 5 DEX, 6 WIL, multi-sword-slash (d12+d12, blast)
 - Critical damage: target is eviscerated, and their swords join the awakening.
 
 ### Gelatinous King (Giant Skeleton)
@@ -44,4 +44,4 @@ redirect_from: /resources/adventure-conversions/a-gathering-of-blades/
 4 HP, 5 STR, 7 DEX, 12 WIL, acidic spray (d6, corrodes armor)
 
 ### Rawg, a 10ft sentient sword
-- Awaits a true master; shrinks to the size of its la/ wielder.
+- Awaits a true master; shrinks to the size of its latest wielder.

--- a/adventures/conversions/the-coming-of-sorg.md
+++ b/adventures/conversions/the-coming-of-sorg.md
@@ -10,7 +10,7 @@ redirect_from: /resources/adventure-conversions/the-coming-of-sorg/
 
 - Original system-neutral [adventure](http://blog.trilemma.com/2014/06/the-coming-of-sorg.html) by Michael Prescott. Michael Prescott. Updated version [available](https://www.drivethrurpg.com/product/286792/Trilemma-Adventures-Compendium-Volume-I).
 - Original conversion by [Jason Tocci](https://jasontocci.itch.io/agents-of-the-odd/devlog/180126/adapting-scenarios-for-agents-of-the-odd).
-- Additional conversion by [Daniel Soilbuilder](https://danielsoilbuilder.itch.io/)  
+- Additional conversion by [Daniel Soilbuilder](https://danielsoilbuilder.itch.io/)
 - Adapted with permission.
 
 ## Encounters
@@ -20,9 +20,9 @@ redirect_from: /resources/adventure-conversions/the-coming-of-sorg/
 - Crew of 15 heretics is untrained, *impairing* most of their attacks.
 
 ### Cultists
-4 HP, 1 Armor, 14 WIL, mace (d6), Holy Symbol (_Ward_ once per day)  
-- Holy men & women in a quest for their deity.  
-- Normally travel in groups of 4+.  
+4 HP, 1 Armor, 14 WIL, mace (d6), Holy Symbol (_Ward_ once per day)
+- Holy men & women in a quest for their deity.
+- Normally travel in groups of 4+.
 
 ## Sorg Emanations
 
@@ -36,7 +36,7 @@ redirect_from: /resources/adventure-conversions/the-coming-of-sorg/
 - Rhino-sized larva, slow.
 - Protected by 11 acolytes (devoted, but weaponless and deprived---0 HP, attacks *impaired*).
 
-### Toothy in/ine emanation 
+### Toothy intestine emanation 
 - Squeeze (d6), swallow on critical damage.
 
 ### Air leech Swarm Emanation 

--- a/adventures/conversions/the-sky-blind-spire.md
+++ b/adventures/conversions/the-sky-blind-spire.md
@@ -13,7 +13,7 @@ redirect_from: /resources/adventure-conversions/the-sky-blind-spire/
 
 ## Introduction
 
-**Tintardinal’s** spire was to be his grea/ work: A stone tower crafted as a giant arcanum, granting a great reward to those who unlock its secrets. Nobody knows the secrets, though, because **Tintardinal** fell to his death before he could use it.
+**Tintardinal’s** spire was to be his greatest work: A stone tower crafted as a giant arcanum, granting a great reward to those who unlock its secrets. Nobody knows the secrets, though, because **Tintardinal** fell to his death before he could use it.
 
 The spire stands five stories tall, the only structure on a small island in a large lake. Now that  you've had a chance to tether your rowboat and get a close up look, you can see a great door ahead at the end of the path leading from the dock, and windows up the sides of the tower, pointing in each of the directions of the compass. The upper floor windows each seem to have a chain bolted to their sills, dangling down to the window down below (but nothing dangling from the second floor all the way to the ground). The lake is all around you, and beyond that, the scrublands you crossed to get here, mountains in the distance, and the sun just rising over the horizon to the east. The weather’s clear – it’ll be a sunny day with a clear, blue sky.
 
@@ -63,7 +63,7 @@ In addition to the number “six” on the floor, there’s a staircase leading 
 
 ### Undines
 13hp 13 STR, 18 DEX, 15 WIL, pressure jet (d8)
-- _Critical damage_: overwhelmed by the wave and pushed far away.  
+- _Critical damage_: overwhelmed by the wave and pushed far away.
 - Impair any damage against them unless it would freeze/boil water.
 
 ## 8. Room


### PR DESCRIPTION
It appears text replacement was used to add forward slash in https://github.com/yochaigal/cairn/commit/a6e957dce6d5ea442f75b1ec484374e029198690

The side effect was that words with "test" in it, like "greatest", turned into "grea/".
Also trim trailing whitespace.