### PR TITLE
Apply standard for double+ attack where one rolls more than one die, take highest …

### DIFF
--- a/adventures/conversions/a-man-on-the-road.md
+++ b/adventures/conversions/a-man-on-the-road.md
@@ -15,7 +15,7 @@ title: A Man on the Road
 - Hard to Kill: Falls unconscious for 1d6 rounds upon receiving critical damage, then rises with 5 less STR than his previous maximum (surprising anyone looting his corpse) unless finished off (see **Executions Confounded**).
 
 ### His Horse
-7 HP, 1 Armor, 12 STR, 10 DEX, 10 WIL, hooves (1d8+1d8)
+7 HP, 1 Armor, 12 STR, 10 DEX, 10 WIL, hooves (d8+d8)
 
 ### His Weapon of Choice
 1. Saber (1d8, 60 ft. charge doubles damage)

--- a/adventures/conversions/daughter-of-the-dead-king.md
+++ b/adventures/conversions/daughter-of-the-dead-king.md
@@ -56,7 +56,7 @@ Hagstooth Mead - If consumed, the drinker has advantage on WIL saves for an hour
 - Poisoned characters take 1d4 damage each round for 1d4 rounds
 
 ### Three-Headed Giant Snake
-5 HP, 2 Armor, 15 STR, 11 DEX, 5 WIL, bite (1d8+1d8+1d8)
+5 HP, 2 Armor, 15 STR, 11 DEX, 5 WIL, bite (d8+d8+d8)
 - Critical damage - Target is swallowed whole. Swallowed characters take 1d4 damage per turn until dead or cut free.
 
 ### Bog Body

--- a/adventures/conversions/grave-of-the-green-flame.md
+++ b/adventures/conversions/grave-of-the-green-flame.md
@@ -43,7 +43,7 @@ Roll a 1d100 on Cairn’s spell list to determine what spells are on any scrolls
 ## F4 Ambush
 
 ### Lizard man (1)
-4 HP, 1 Armor, 14 STR, 12 DEX, 12 WIL, 1d3+1d3 claw, 1d6+1 bite
+4 HP, 1 Armor, 14 STR, 12 DEX, 12 WIL, d3+d3 claw, 1d6+1 bite
 
 ## I1 Investigating the Tower Grounds
 
@@ -75,7 +75,7 @@ For freeing the Orc, role twice on the bonus item table for a reward.
 
 ## N1 Attack the Axe Beak
 ### Axe beak (1)
-6 HP, talon (1d3+1d3), beak (2d4)
+6 HP, talon (d3+d3), beak (2d4)
 
 ## O2 The Altar
 If you decide to place your weapon on the altar, determine first what your character’s intentions for the weapon are.
@@ -96,7 +96,7 @@ The player gets +1 WIL.
 
 ## Q2 Investigate the canoe/Q3 Frog Attack
 ### Killer Frogs
-5 HP, 5 STR, claw (1d2+1d2), 1d4 bite
+5 HP, 5 STR, claw (d2+d2), 1d4 bite
 
 ## X2 Assault the Cabin
 ### Bandits (3)

--- a/adventures/conversions/tomb-of-the-serpent-kings.md
+++ b/adventures/conversions/tomb-of-the-serpent-kings.md
@@ -35,7 +35,7 @@ redirect_from: /resources/adventure-conversions/tomb-of-the-serpent-kings/
 - If separated, will scurry off
 
 ####  Stone Cobra Guardian
-10 HP, 3 Armor, 16 STR, 11 DEX, 15 WIL, Shield Draw (1d6, shield can be sundered for -1d12 damage once per shield), Leap and Slam (1d4, forces prone, next attack Enhanced unless players use action to get up and avoid damage), Twin Slash (1d8+1d8, two targets)
+10 HP, 3 Armor, 16 STR, 11 DEX, 15 WIL, Shield Draw (1d6, shield can be sundered for -1d12 damage once per shield), Leap and Slam (1d4, forces prone, next attack Enhanced unless players use action to get up and avoid damage), Twin Slash (d8+d8, two targets)
 - Turns slowly
 - Will switch targets if player is being evasive
 - Does actions in order, unless it still has a shield, in which case it skips Shield Draw

--- a/adventures/conversions/where-the-wheat-grows-tall.md
+++ b/adventures/conversions/where-the-wheat-grows-tall.md
@@ -90,7 +90,7 @@ redirect_from: /resources/adventure-conversions/where-the-wheat-grows-tall/
 4 HP, 8 STR, 5 DEX, 11 WIL, farming tool (d6)
 
 ### Trull The Troll
-8 HP, 2 Armor, 14 STR, 11 DEX, 11 WIL, toadslap (1d6+1d6, _blast_)
+8 HP, 2 Armor, 14 STR, 11 DEX, 11 WIL, toadslap (d6+d6, _blast_)
 - Critical damage: characters are hurled into stream.
 - In shadowed water regenerates 2 STR per round.
 


### PR DESCRIPTION
… is without qualifier on number of dice (it's d8+d8 rather than 1d8+1d8)

Special mention is Three-Headed Giant Snake - first time I see a thrice advantage which still should look like (d8+d8+d8) I think