### PR TITLE
Provide improved version of the Cairn monster importer

### DIFF
--- a/generate_monster_json.rb
+++ b/generate_monster_json.rb
@@ -12,23 +12,52 @@ class Monster
 
   attr_reader :markdown
 
+  # Search for the first line that matches the header pattern (#)
   def name
-    markdown[4].match(/#\s*(.*)/)&.send(:[], 1)&.strip
+    header_line = markdown.find { |line| line.match(/^#\s*(.*)/) }
+    header_line&.match(/^#\s*(.*)/)&.send(:[], 1)&.strip
+  end
+
+  # Extracts the stats like HP, STR, DEX, WIL, armor, and all attacks from the markdown
+  def stats
+    stats_line = markdown.find { |line| line.match(/\d+ HP/) }
+    return {} unless stats_line
+
+    # Extract HP, Armor, STR, DEX, WIL
+    hp = stats_line.match(/(\d+)\s*HP/)&.send(:[], 1)
+    armor = stats_line.match(/(\d+)\s*Armor/)&.send(:[], 1) # Capture the Armor value if present
+    str = stats_line.match(/(\d+)\s*STR/)&.send(:[], 1)
+    dex = stats_line.match(/(\d+)\s*DEX/)&.send(:[], 1)
+    wil = stats_line.match(/(\d+)\s*WIL/)&.send(:[], 1)
+
+    # Extract all attacks (e.g., "ceremonial dagger (d6), club (d10)")
+    attacks = stats_line.scan(/([a-zA-Z\s]+)\s*\((.*?)\)/).map do |attack, damage|
+      { name: attack.strip, damage: damage }
+    end
+
+    { hp: hp, armor: armor, str: str, dex: dex, wil: wil, attacks: attacks }
   end
 
   def description
     renderer = Redcarpet::Render::HTML.new
     redcarpet = Redcarpet::Markdown.new(renderer)
-    redcarpet.render(markdown[6, (markdown.size - 7)].join)
+    # The description starts after the metadata and the header
+    redcarpet.render(markdown.drop_while { |line| !line.match(/^#/) }.drop(1).join)
   end
 end
 
-monsters = Dir.glob('monsters/*')
-
-monsters = monsters.map do |monster|
-  markdown = File.readlines(monster)
+# Process all markdown files in the "monsters" folder
+monsters = Dir.glob('monsters/*.md').map do |monster_file|
+  markdown = File.readlines(monster_file)
   monster = Monster.new(markdown)
-  { name: monster.name, description: monster.description }
+
+  {
+    name: monster.name,
+    description: monster.description,
+    stats: monster.stats
+  }
 end.to_json
 
+# Output the JSON
 puts JSON.pretty_generate(JSON.parse(monsters))
+

--- a/resources/foundryvtt-system.md
+++ b/resources/foundryvtt-system.md
@@ -9,6 +9,8 @@ nav_order: 3
 # Foundry VTT System  
 Cairn has a robust system for [Foundry VTT](https://foundryvtt.com/), the popular virtual tabletop program. You can install Cairn directly from within Foundry, or you can do so manually via the [Github Repo](https://github.com/yochaigal/Cairn-FoundryVTT).
 
+There are a number of compendium packs (and one macro) that must be imported into the "world"; make sure that all players have the "Observer" permissions so that they can generate a character themselves. You'll also need to change the "Player" Role permissions to allow them to create Actors.
+
 ## Automatic Monster Import
 
 This guide describes how to automate the process of importing monster descriptions and stats into [Foundry VTT](https://foundryvtt.com/) using a combination of Ruby and JavaScript. The process allows for seamless conversion of monster data from markdown to JSON, and then automatically creates or updates actors within Foundry VTT.

--- a/resources/foundryvtt-system.md
+++ b/resources/foundryvtt-system.md
@@ -1,42 +1,225 @@
 ---
 layout: default
 redirect_from: /resources/tools/foundryvtt-system
-title: Foundry VTT System
+title: Foundry VTT System with Automatic Monster Import
 parent: Resources
 nav_order: 3
 ---
 
-# Foundry VTT System
+# Foundry VTT System with Automatic Monster Import
 
-Cairn has a robust system for [Foundry VTT](https://foundryvtt.com/), the popular virtual tabletop program. You can install Cairn directly from within Foundry, or you can do so manually via the [Github Repo](https://github.com/yochaigal/Cairn-FoundryVTT).
+This guide describes how to automate the process of importing monster descriptions and stats into [Foundry VTT](https://foundryvtt.com/) using a combination of Ruby and JavaScript. The process allows for seamless conversion of monster data from markdown to JSON, and then automatically creates or updates actors within Foundry VTT.
 
-There are a number of compendium packs (and one macro) that must be imported into the "world"; make sure that all players have the "Observer" permissions so that they can generate a character themselves. You'll also need to change the "Player" Role permissions to allow them to create Actors.
+## Prerequisites
+1. **Foundry VTT**: Ensure you have Foundry VTT installed and set up.
+2. **Ruby**: You'll need Ruby installed on your system.
+3. **Redcarpet Gem**: The Ruby script requires the `redcarpet` gem to parse markdown. Install it by running:
+   ```bash
+   gem install redcarpet
+   ```
 
-## Import Monster Descriptions into Foundry VTT automatically
-[Stephen Mariano Cabrera](https://github.com/smcabrera) has created an excellent little Ruby script that converts monster descriptions from markdown and into JSON format, which can then be imported into Foundry with Javascript. Here is how you do it:
-- Create monster Actors in Foundry; you can ignore descriptions for now.
-- Ensure that the monsters are all in written in markdown (see examples [here](https://github.com/yochaigal/cairn/tree/main/monsters)). Put them all in a folder called "monsters" or modify script to match something else.
-- Grab the Ruby script from the Cairn [github repo](https://github.com/yochaigal/cairn/blob/main/generate_monster_json.rb) and put it the same folder.
-- Make sure you have ruby; you will need to install the redcarpet gem as well.
-- Run generate_monster_json.rb > monsters.json.
-- Open monsters.json and copy the text to clipboard.
-- Within Foundry's Script editor, create a new script and copy this script into it:
+## Step-by-Step Guide
 
+### 1. Prepare Your Monsters in Markdown
+
+Make sure your monsters are written in markdown format. Each file should include all relevant stats, including HP, STR, DEX, WIL, armor, and attacks. For example:
+
+```markdown
+# Black Dragon
+
+16 HP, 1 Armor, 13 STR, 18 DEX, 14 WIL, bite (d12), claws (d10+d10)
+- Amphibious dragons with glossy black scales and thick hides. 
+- Dwell in swamps or similarly dangerous environments.
 ```
-let monstersJson =  [monsters.json contents]
 
-let updateActor = function(monstersJson) {
-let  monsterActor = game.actors.entities.find(actor => actor.name == monstersJson.name)
-  if (monsterActor == undefined) {
-    console.log(monstersJson)
-  } else {
-    monsterActor.update({ "data": { "description": monstersJson.description }})
-  }
+Ensure all your markdown files are placed in a folder called `monsters`.
+
+### 2. Run the Ruby Script
+
+Download the Ruby script [from the repository](https://github.com/yochaigal/cairn/blob/main/generate_monster_json.rb). Place the script in the same directory as your `monsters` folder. The script reads the markdown files, extracts the monster stats, and outputs a JSON file with all the monster data.
+
+To run the script:
+
+```bash
+ruby generate_monster_json.rb > monsters.json
+```
+
+This will generate a `monsters.json` file in the same folder, containing all the parsed monster data.
+
+### 3. Import the Monsters into Foundry VTT
+
+Now that you have your `monsters.json`, you can import the data into Foundry VTT.
+
+1. **Open Foundry VTT** and create a new script macro.
+2. Copy the following JavaScript code into the editor:
+
+```javascript
+// Prompt the user for JSON input
+let jsonInput = await new Promise((resolve) => {
+  new Dialog({
+    title: "Monster JSON Input",
+    content: `<textarea id="json-input" style="width:100%;height:200px;"></textarea>`,
+    buttons: {
+      ok: {
+        label: "OK",
+        callback: (html) => resolve(html.find("#json-input").val())
+      }
+    }
+  }).render(true);
+});
+
+// Parse the user input JSON
+let monstersJson;
+try {
+  monstersJson = JSON.parse(jsonInput);
+} catch (e) {
+  ui.notifications.error("Invalid JSON. Please try again.");
+  throw e;
 }
-monstersJson.forEach(m => updateActor(m))
+
+// Find the "monsters" folder, create it if it doesn't exist
+let monsterFolder = game.folders.find(folder => folder.name == "monsters" && folder.type == "Actor");
+if (monsterFolder == undefined) {
+    monsterFolder = await Folder.create({ name: "monsters", type: "Actor" });
+}
+
+let updateActor = async function(monsterData) {
+    // Check if the monster actor already exists
+    let monsterActor = game.actors.find(actor => actor.name == monsterData.name);
+    if (monsterActor == undefined) {
+        // Create a new actor inside the "monsters" folder with the correct structure
+        let actorData = {
+            name: monsterData.name,
+            type: "npc",
+            folder: monsterFolder.id,
+            system: {
+                hp: {
+                    value: parseInt(monsterData.stats.hp),
+                    max: parseInt(monsterData.stats.hp)
+                },
+                abilities: {
+                    STR: {
+                        value: parseInt(monsterData.stats.str),
+                        max: parseInt(monsterData.stats.str)
+                    },
+                    DEX: {
+                        value: parseInt(monsterData.stats.dex),
+                        max: parseInt(monsterData.stats.dex)
+                    },
+                    WIL: {
+                        value: parseInt(monsterData.stats.wil),
+                        max: parseInt(monsterData.stats.wil)
+                    }
+                },
+                description: monsterData.description
+            },
+            items: monsterData.stats.attacks.map(attack => ({
+                name: attack.name,
+                type: "item", // Define this as an item
+                system: {
+                    damageFormula: attack.damage,
+                    equipped: true // Ensure the item is equipped
+                }
+            })),
+            prototypeToken: {
+                name: monsterData.name,
+                bar1: { attribute: "system.hp" },
+                bar2: { attribute: "system.abilities.STR" }
+            }
+        };
+
+        // Create the actor
+        monsterActor = await Actor.create(actorData);
+
+        // If armor is present, create and equip a Default Armor item
+        if (monsterData.stats.armor) {
+            let armorItem = {
+                name: "Default Armor",
+                type: "armor",
+                img: "icons/svg/item-bag.svg", // Placeholder image
+                system: {
+                    armor: parseInt(monsterData.stats.armor),
+                    equipped: true,  // Automatically equip the armor
+                    bulky: false,
+                    weightless: false,
+                    uses: {
+                        value: 0,
+                        max: 0
+                    }
+                }
+            };
+
+            // Add the armor item to the actor
+            await monsterActor.createEmbeddedDocuments("Item", [armorItem]);
+        }
+    } else {
+        // Update the actor's description, stats, and items if it already exists
+        let updateData = {
+            "system.hp.value": parseInt(monsterData.stats.hp),
+            "system.hp.max": parseInt(monsterData.stats.hp), // Set the max HP here
+            "system.abilities.STR.value": parseInt(monsterData.stats.str),
+            "system.abilities.STR.max": parseInt(monsterData.stats.str), // Set the max STR here
+            "system.abilities.DEX.value": parseInt(monsterData.stats.dex),
+            "system.abilities.DEX.max": parseInt(monsterData.stats.dex), // Set the max DEX here
+            "system.abilities.WIL.value": parseInt(monsterData.stats.wil),
+            "system.abilities.WIL.max": parseInt(monsterData.stats.wil), // Set the max WIL here
+            "system.description": monsterData.description
+        };
+
+        await monsterActor.update(updateData);
+
+        // Update or add the attacks (items)
+        let attackItems = monsterData.stats.attacks.map(attack => ({
+            name: attack.name,
+            type: "item",
+            system: {
+                damageFormula: attack.damage,
+                equipped: true // Ensure the item is equipped
+            }
+        }));
+
+        // Update the items (replace or add)
+        await monsterActor.updateEmbeddedDocuments("Item", attackItems);
+
+        // If armor is present, create and equip a Default Armor item if not already present
+        if (monsterData.stats.armor) {
+            let existingArmor = monsterActor.items.find(i => i.name === "Default Armor");
+            if (!existingArmor) {
+                let armorItem = {
+                    name: "Default Armor",
+                    type: "armor",
+                    img: "icons/svg/item-bag.svg", // Placeholder image
+                    system: {
+                        armor: parseInt(monsterData.stats.armor),
+                        equipped: true,  // Automatically equip the armor
+                        bulky: false,
+                        weightless: false,
+                        uses: {
+                            value: 0,
+                            max: 0
+                        }
+                    }
+                };
+
+                // Add the armor item to the actor
+                await monsterActor.createEmbeddedDocuments("Item", [armorItem]);
+            }
+        }
+    }
+};
+
+// Iterate over all monsters and update or create them
+monstersJson.forEach(m => updateActor(m));
 ```
 
-As you can see, the contents of monsters.json should go in between the brackets in the first line.
-That's it. Execute the macro.
+### 4. Paste Your JSON Data
 
-Perhaps one day you should be able to run the script without creating the Actors first. I hope this method saves you some time, regardless.
+Once you've created a new Foundry VTT macro and copied the above script into it, save the macro and run it. A dialog box will appear, allowing you to paste the contents of `monsters.json` into the field. After pasting, click "OK" to run the import process.
+
+### 5. Enjoy
+
+The script will create or update your monster actors, including their stats, descriptions, attacks, and armor. All items, such as weapons and armor, will be automatically equipped.
+
+---
+
+And that's it! You've now automated the process of importing monsters into Foundry VTT from markdown files, saving you valuable time.

--- a/resources/foundryvtt-system.md
+++ b/resources/foundryvtt-system.md
@@ -12,7 +12,7 @@ This guide describes how to automate the process of importing monster descriptio
 
 ## Prerequisites
 1. **Foundry VTT**: Ensure you have Foundry VTT installed and set up.
-2. **Ruby**: You'll need Ruby installed on your system.
+2. **Ruby**: You'll need Ruby installed on your system. [Learn how here](https://www.ruby-lang.org/en/documentation/installation/)
 3. **Redcarpet Gem**: The Ruby script requires the `redcarpet` gem to parse markdown. Install it by running:
    ```bash
    gem install redcarpet

--- a/resources/foundryvtt-system.md
+++ b/resources/foundryvtt-system.md
@@ -6,11 +6,14 @@ parent: Resources
 nav_order: 3
 ---
 
-# Foundry VTT System with Automatic Monster Import
+# Foundry VTT System  
+Cairn has a robust system for [Foundry VTT](https://foundryvtt.com/), the popular virtual tabletop program. You can install Cairn directly from within Foundry, or you can do so manually via the [Github Repo](https://github.com/yochaigal/Cairn-FoundryVTT).
+
+## Automatic Monster Import
 
 This guide describes how to automate the process of importing monster descriptions and stats into [Foundry VTT](https://foundryvtt.com/) using a combination of Ruby and JavaScript. The process allows for seamless conversion of monster data from markdown to JSON, and then automatically creates or updates actors within Foundry VTT.
 
-## Prerequisites
+### Prerequisites
 1. **Foundry VTT**: Ensure you have Foundry VTT installed and set up.
 2. **Ruby**: You'll need Ruby installed on your system. [Learn how here](https://www.ruby-lang.org/en/documentation/installation/)
 3. **Redcarpet Gem**: The Ruby script requires the `redcarpet` gem to parse markdown. Install it by running:
@@ -18,9 +21,9 @@ This guide describes how to automate the process of importing monster descriptio
    gem install redcarpet
    ```
 
-## Step-by-Step Guide
+### Step-by-Step Guide
 
-### 1. Prepare Your Monsters in Markdown
+#### 1. Prepare Your Monsters in Markdown
 
 Make sure your monsters are written in markdown format. Each file should include all relevant stats, including HP, STR, DEX, WIL, armor, and attacks. For example:
 
@@ -34,7 +37,7 @@ Make sure your monsters are written in markdown format. Each file should include
 
 Ensure all your markdown files are placed in a folder called `monsters`.
 
-### 2. Run the Ruby Script
+#### 2. Run the Ruby Script
 
 Download the Ruby script [from the repository](https://github.com/yochaigal/cairn/blob/main/generate_monster_json.rb). Place the script in the same directory as your `monsters` folder. The script reads the markdown files, extracts the monster stats, and outputs a JSON file with all the monster data.
 
@@ -46,7 +49,7 @@ ruby generate_monster_json.rb > monsters.json
 
 This will generate a `monsters.json` file in the same folder, containing all the parsed monster data.
 
-### 3. Import the Monsters into Foundry VTT
+#### 3. Import the Monsters into Foundry VTT
 
 Now that you have your `monsters.json`, you can import the data into Foundry VTT.
 
@@ -212,11 +215,11 @@ let updateActor = async function(monsterData) {
 monstersJson.forEach(m => updateActor(m));
 ```
 
-### 4. Paste Your JSON Data
+#### 4. Paste Your JSON Data
 
 Once you've created a new Foundry VTT macro and copied the above script into it, save the macro and run it. A dialog box will appear, allowing you to paste the contents of `monsters.json` into the field. After pasting, click "OK" to run the import process.
 
-### 5. Enjoy
+#### 5. Enjoy
 
 The script will create or update your monster actors, including their stats, descriptions, attacks, and armor. All items, such as weapons and armor, will be automatically equipped.
 


### PR DESCRIPTION
#### What’s New
This update makes it easier to import monster data from markdown files straight into Foundry VTT, without the hassle of manually creating actors. 

#### Key Changes:
1. **Ruby Script for Markdown to JSON:**
   - The Ruby script reads markdown files in a `monsters` folder and pulls out the relevant monster stats like HP, Armor, STR, DEX, WIL, and attacks.
   - It then generates a `monsters.json` file with all this data ready to go.

2. **No More Manual Actor Creation:**
   - The JavaScript script in Foundry now creates or updates actors automatically based on the JSON file you generate. You paste the JSON directly into Foundry, and the script does the rest — adding stats, descriptions, attacks, and armor to the monster actors.

#### Why This is Awesome
No more tedious actor creation! This setup lets you quickly take monster descriptions from markdown and turn them into fully fleshed-out actors in Foundry VTT with just a couple of scripts. It handles stats, equips items, and makes setting up encounters much smoother.

Honestly, I’m not sure how often these scripts are used nowadays, but they were one of the first things I stumbled across while looking for Foundry integrations for Cairn. I just wanted to make them better and hopefully make life easier for anyone still using them. :)