### PR TITLE
Fixed broken link formatting

### DIFF
--- a/resources/useful-links.md
+++ b/resources/useful-links.md
@@ -57,4 +57,4 @@ Sam is the author of Skorne and Adventure Hour, and writes on Into The Odd (and 
 - Tabletop Sandbox: ["D&D 5e has two many rules"](https://youtu.be/FGyB4Y4pFP4)
 - By Odin's Beard: ["How is Cairn Different from D&D 5e"](https://www.youtube.com/watch?v=3vQTAa8rIzg)
 - Jorphdan's Jocular Junction: ["Taking Cairn of Business"](https://youtu.be/x0LJAruoxks?si=oVIa51TgdkVih7dQ)
-- Axe Wizard: "Cairn 2e Worldbuilding](https://www.youtube.com/watch?v=TpvejI8ivtg&t=2073s)  
+- Axe Wizard: ["Cairn 2e Worldbuilding"](https://www.youtube.com/watch?v=TpvejI8ivtg)


### PR DESCRIPTION
Fixed broken link formatting in the final video linked on the `useful-links.md` page. Also slightly edited the link to remove the hardcoded timestamp so the link takes users to the start of the video rather than the middle.