### PR TITLE
Enhance Warden's Guide Table of Contents to align with book/PDF

### DIFF
--- a/second-edition/wardens-guide.md
+++ b/second-edition/wardens-guide.md
@@ -4,8 +4,46 @@ title: Warden's Guide
 parent: Second Edition
 has_children: true
 nav_order: 3
+has_toc: false
 ---
 
 # Warden's Guide
 
 The Warden’s Guide includes tools, tables, and advice for running Cairn, with procedures to generate content that fits into the Vald setting or any fantasy world of your imagining. The following chapters offer resources and detailed instructions for creating immersive adventures, with an emphasis on dynamic gameplay and rich worldbuilding. It is our hope that with these pages anyone can craft unique, challenging experiences that engage and captivate players.
+
+* * *
+
+## Table of Contents
+
+### Part 1: World Building
+- [Setting Seeds](setting-seeds)
+- [Factions](setting-seeds#factions)
+- [Topography](setting-seeds#topography)
+- [Dungeon Seeds](dungeon-seeds)
+- [Forest Seeds](forest-seeds)
+
+### Part 2: Warden's Tools
+- [Bestiary](bestiary)
+- [Creating Monsters](creating-monsters)
+- [Naming Procedures](naming-procedures)
+- [Growth](growth)
+- [Spellbooks](spellbooks)
+- [Reliquary](reliquary)
+
+### Part 3: Advice & Examples
+- [Creating Backgrounds](creating-backgrounds)
+- [Pointcrawls](pointcrawls)
+- _Frequently Asked Questions_
+  - [About the Example Party](about-the-example-party)
+  - [Dungeon Exploration](dungeon-exploration)
+  - [Detachments](detachments)
+  - [Wilderness Exploration](wilderness-exploration)
+  - [Bonds and Omens](bonds-and-omens)
+  - [Knowledge and Perception](knowledge-and-perception)
+  - [Saves](saves)
+  - [Variable Difficulty](variable-difficulty)
+  - [Combat](combat)
+- _The Setting of Vald_
+  - [Vald](vald)
+  - [NPC Tables](npc-tables)
+- [Bibliography](bibliography)


### PR DESCRIPTION
Manually set Warden's Guide Table of Contents to better align with book/PDF.

Screenshot of the proposed changes:
<img width="2882" height="1802" alt="Screen Shot 2026-01-09 at 09 08 23" src="https://github.com/user-attachments/assets/ee192762-61ed-4df5-84ab-f2c60fbd6636" />

* * *

Question for @yochaigal, do you think we should re-order the side navigation to match, or should we keep alphabetical?