### PR TITLE
Remove dead Third Party Hack links

### DIFF
--- a/hacks/third-party/even-more-third-party-hacks.md
+++ b/hacks/third-party/even-more-third-party-hacks.md
@@ -17,10 +17,8 @@ nav_order: 20
 * [**Mangayaw**](https://mangayaw.carrd.co) by [Goobernuts](https://goobernutsblog.wordpress.com/)
 * [**Meteor**](https://www.meteorrpg.com/)
 * [**Monolith**](https://adamhensley.itch.io/monolith)
-* [**NEANDERTAL**](https://natetreme.com/blog/neandertal)
 * [**Plerion**](https://plerion.zeruhur.space/)
 * [**Runecairn**](https://byodinsbeardrpg.itch.io/runecairn)
-* [**Thalassa**](https://zeruhur.itch.io/thalassa)
 * [**Cyber**](https://oskarswida.itch.io/cyber-eng)
 
 ## Supplements


### PR DESCRIPTION
On the page ["Event More Third Party Hacks"](https://cairnrpg.com/hacks/third-party/even-more-third-party-hacks/)

The following hacks are no longer hosted at the URLs provided:

* [NEANDERTAL](https://natetreme.com/blog/neandertal)
* [Thalassa](https://zeruhur.itch.io/thalassa)

These changes remove these links from the list of Complete Hacks.