### PR TITLE
Demote 'Panic' header in procedures.md

### DIFF
--- a/second-edition/players-guide/procedures.md
+++ b/second-edition/players-guide/procedures.md
@@ -62,7 +62,7 @@ When the party:
 - A light source and a _safe location_ are required to **rest**. Present or oncoming danger makes **rest** impossible.
 - **Resting** does not restore **Fatigue**, as it is impossible to safely **Make Camp** in a dungeon.
 
-## Panic
+### Panic
 
 - A character that is surrounded by enemies, enveloped by darkness, or facing their greatest fears may experience _panic_. A **WIL** **save** is typically required to avoid losing control and becoming _panicked_. 
 - A _panicked_ character must make a **WIL** **save** to overcome their condition as an **action** on their **turn**.


### PR DESCRIPTION
"Panic" heading is at Heading 2 level, which does not flow well with the surrounding content, being followed by Heading 3 "Dungeon Elements" suggesting it is a subsection of "Panic".

This is likely a typo, which should be corrected, demoting "Panic" from Heading 2 to Heading 3.